### PR TITLE
Update gem5Run to use factory pattern

### DIFF
--- a/artifact/setup.py
+++ b/artifact/setup.py
@@ -10,7 +10,7 @@ with open(Path(__file__).parent / 'README.md', encoding='utf-8') as f:
 
 setup(
     name = "gem5art-artifact",
-    version = "0.1.4",
+    version = "0.2.0",
     description = "Artifacts for gem5art",
     long_description = long_description,
     long_description_content_type='text/markdown',

--- a/run/setup.py
+++ b/run/setup.py
@@ -10,7 +10,7 @@ with open(Path(__file__).parent / 'README.md', encoding='utf-8') as f:
 
 setup(
     name = "gem5art-run",
-    version = "0.1.4",
+    version = "0.2.0",
     description = "A collection of utilities for running gem5",
     long_description = long_description,
     long_description_content_type='text/markdown',

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -10,7 +10,7 @@ with open(Path(__file__).parent / 'README.md', encoding='utf-8') as f:
 
 setup(
     name = "gem5art-tasks",
-    version = "0.1.3",
+    version = "0.2.0",
     description = "A celery app for gem5art",
     long_description = long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Instead of using inheiritance to have two different constructors for
gem5Run (one for FS and one for SE), use the factory pattern. This
greatly simplifies the code to load from the database fixing a bug where
some members of the class were overwritten by the constructor when
loading from the database.

Signed-off-by: Jason Lowe-Power <jason@lowepower.com>