### PR TITLE
Fix import to have fewer artifacts

### DIFF
--- a/artifact/gem5art/artifact/__init__.py
+++ b/artifact/gem5art/artifact/__init__.py
@@ -29,12 +29,6 @@
 
 """This is the gem5 artifact package"""
 
-from gem5art.artifact._artifactdb import ArtifactDB
-
-def getDBConnection() -> ArtifactDB:
-    """Returns the database connection
-
-    Eventually, this should likely read from a config file to get the database
-    information. However, for now, we'll use mongodb defaults
-    """
-    return ArtifactDB()
+from .artifact import Artifact
+from .artifact import getByName, getDiskImages, getLinuxBinaries, getgem5Binaries
+from ._artifactdb import ArtifactDB, getDBConnection

--- a/artifact/gem5art/artifact/_artifactdb.py
+++ b/artifact/gem5art/artifact/_artifactdb.py
@@ -88,3 +88,11 @@ class ArtifactDB:
         file if it currently exists."""
         with open(path, 'wb') as f:
             self.fs.download_to_stream(key, f)
+
+def getDBConnection() -> ArtifactDB:
+    """Returns the database connection
+
+    Eventually, this should likely read from a config file to get the database
+    information. However, for now, we'll use mongodb defaults
+    """
+    return ArtifactDB()

--- a/artifact/gem5art/artifact/artifact.py
+++ b/artifact/gem5art/artifact/artifact.py
@@ -38,8 +38,7 @@ import time
 from typing import Any, Dict, Iterator, List, Union
 from uuid import UUID, uuid4
 
-from . import getDBConnection
-
+from ._artifactdb import getDBConnection
 
 _db = getDBConnection()
 

--- a/artifact/tests/test_artifact.py
+++ b/artifact/tests/test_artifact.py
@@ -34,16 +34,16 @@ from os.path import exists
 import unittest
 from uuid import uuid4
 
-from gem5art.artifact import artifact
+from gem5art import artifact
 
 class TestGit(unittest.TestCase):
     def test_keys(self):
-        git = artifact.getGit('.')
+        git = artifact.artifact.getGit('.')
         self.assertSetEqual(set(git.keys()), set(['origin', 'hash', 'name']),
                             "git keys wrong")
 
     def test_origin(self):
-        git = artifact.getGit('.')
+        git = artifact.artifact.getGit('.')
         self.assertTrue(git['origin'].endswith('gem5art'),
                         "Origin should end with gem5art")
 
@@ -58,7 +58,7 @@ class TestArtifact(unittest.TestCase):
             'command': ['ls', '-l'],
             'path': '/',
             'hash': hashlib.md5().hexdigest(),
-            'git': artifact.getGit('.'),
+            'git': artifact.artifact.getGit('.'),
             'cwd': '/',
             'inputs': [],
         })

--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -46,7 +46,7 @@ from uuid import UUID, uuid4
 import zipfile
 
 from gem5art import artifact
-from gem5art.artifact.artifact import Artifact
+from gem5art.artifact import Artifact
 
 _db: artifact.ArtifactDB = artifact.getDBConnection()
 


### PR DESCRIPTION
Signed-off-by: Jason Lowe-Power <jason@lowepower.com>

BTW, I think this is going to require changes in the documentation and everything that uses gem5art. This makes it so where you had `from gem5art.artifact import artifact` it's now `from gem5art import artifact`.