### PR TITLE
Add option to set output path dir

### DIFF
--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -142,6 +142,7 @@ class gem5Run:
     def createSERun(cls,
                     gem5_binary: str,
                     run_script: str,
+                    relative_outdir: str,
                     gem5_artifact: Artifact,
                     gem5_git_artifact: Artifact,
                     run_script_git_artifact: Artifact,
@@ -172,14 +173,8 @@ class gem5Run:
 
         run.string = f"{run.gem5_name} {run.script_name}"
         run.string += ' '.join(run.params)
-
-        # Constructs the output directory from the gem5 build opts (e.g., X86,
-        # ARM, MOESI_hammer), the gem5 run script, and the extra parameters.
-        # The relative path is useful for printing
-        run.relative_outdir = os.path.join('results',
-                                           run.gem5_name,
-                                           run.script_name,
-                                           *run.params)
+        
+        run.relative_outdir = relative_outdir
 
         run.outdir = os.path.abspath(run.relative_outdir)
         # Make the directory if it doesn't exist
@@ -202,6 +197,7 @@ class gem5Run:
     def createFSRun(cls,
                     gem5_binary: str,
                     run_script: str,
+                    relative_outdir: str,
                     gem5_artifact: Artifact,
                     gem5_git_artifact: Artifact,
                     run_script_git_artifact: Artifact,
@@ -240,16 +236,8 @@ class gem5Run:
         run.string = f"{run.gem5_name} {run.script_name} "
         run.string += f"{run.linux_name} {run.disk_name} "
         run.string += ' '.join(run.params)
-
-        # Constructs the output directory from the gem5 build opts (e.g., X86,
-        # ARM, MOESI_hammer), the gem5 run script, and the extra parameters.
-        # The relative path is useful for printing
-        run.relative_outdir = os.path.join('results',
-                                           run.gem5_name,
-                                           run.script_name,
-                                           run.linux_name,
-                                           run.disk_name,
-                                           *run.params)
+        
+        run.relative_outdir = relative_outdir
 
         run.outdir = os.path.abspath(run.relative_outdir)
         # Make the directory if it doesn't exist

--- a/run/tests/test_run.py
+++ b/run/tests/test_run.py
@@ -83,7 +83,8 @@ class TestSERun(unittest.TestCase):
         self.run = gem5Run.createSERun(
 		'gem5/build/X86/gem5.opt',
 		'configs-tests/run_test.py',
-		self.gem5art,
+		'results/run_test/out',
+                self.gem5art,
 		self.gem5gitart,
 		self.runscptart,
 		'extra','params'
@@ -91,13 +92,13 @@ class TestSERun(unittest.TestCase):
 
     def test_out_dir(self):
         self.assertEqual(self.run.relative_outdir,
-                'results/X86/run_test/extra/params')
+                'results/run_test/out')
 
     def test_command(self):
         self.assertEqual(self.run.command,
         ['gem5/build/X86/gem5.opt', '-re',
         '--outdir={}'.format(os.path.abspath(
-        'results/X86/run_test/extra/params')),
+        'results/run_test/out')),
         'configs-tests/run_test.py',
         'extra', 'params']
         )


### PR DESCRIPTION
This change will require updates in launch scripts and documentation as well. This change completely relies on the user to pass the output result dir path. Maybe we can keep both options here i.e. if a user does not provide output path, gem5art will construct the outdir path by itself ?