### PR TITLE
Adding `name` field to gem5Run objects

### DIFF
--- a/run/tests/test_run.py
+++ b/run/tests/test_run.py
@@ -81,6 +81,7 @@ class TestSERun(unittest.TestCase):
             })
 
         self.run = gem5Run.createSERun(
+		'test SE run',
 		'gem5/build/X86/gem5.opt',
 		'configs-tests/run_test.py',
 		'results/run_test/out',


### PR DESCRIPTION
(Edited) gem5Run objects now have a modifiable `name` field. Two functions, getRunsByName() and getRunsByNameContaining(), will return gem5Run objects containing the name. The `name` field is a required parameter to create a run.