### PR TITLE
Update the checkArtifacts in run.py

### DIFF
--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -298,7 +298,7 @@ class gem5Run:
                 setattr(run, k, v)
         return run
 
-    def checkArtifacts(self) -> bool:
+    def checkArtifacts(self, cwd: str) -> bool:
         """Checks to make sure all of the artifacts are up to date
 
         This should happen just before running gem5. This function will return
@@ -308,14 +308,14 @@ class gem5Run:
         """
         for v in self.artifacts:
             if v.type == 'git repo':
-                new = artifact.artifact.getGit(v.path)['hash']
+                new = artifact.artifact.getGit(os.path.join(cwd,v.path))['hash']
                 old = v.git['hash']
             else:
-                new = artifact.artifact.getHash(v.path)
+                new = artifact.artifact.getHash(os.path.join(cwd,v.path))
                 old = v.hash
 
             if new != v.hash:
-                status = f"Failed artifact check for {v.path}"
+                status = f"Failed artifact check for {os.path.join(cwd,v.path)}"
                 return False
 
         return True
@@ -415,7 +415,7 @@ class gem5Run:
         self.status = "Begin run"
         self.dumpJson('info.json')
 
-        if not self.checkArtifacts():
+        if not self.checkArtifacts(cwd):
             self.dumpJson('info.json')
             return
 

--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -308,14 +308,14 @@ class gem5Run:
         """
         for v in self.artifacts:
             if v.type == 'git repo':
-                new = artifact.artifact.getGit(os.path.join(cwd,v.path))['hash']
+                new = artifact.artifact.getGit(os.path.join(cwd, v.path))['hash']
                 old = v.git['hash']
             else:
-                new = artifact.artifact.getHash(os.path.join(cwd,v.path))
+                new = artifact.artifact.getHash(os.path.join(cwd, v.path))
                 old = v.hash
 
             if new != v.hash:
-                status = f"Failed artifact check for {os.path.join(cwd,v.path)}"
+                status = f"Failed artifact check for {os.path.join(cwd, v.path)}"
                 return False
 
         return True


### PR DESCRIPTION
When celery is run by a different user, all the artifacts
belonging to a run object should have their paths updated
for getHash and getGit functions to not fail. This change
appends the cwd parmeter passed by the user to the paths of
these artifacts.
