### PR TITLE
Prevent SPEC2017 from calling sysinfo

### DIFF
--- a/docs/disks/spec2017/install-spec2017.sh
+++ b/docs/disks/spec2017/install-spec2017.sh
@@ -26,3 +26,6 @@ sed -i "s/command_add_redirect = 1/sysinfo_program =\ncommand_add_redirect = 1/g
 
 # build all SPEC workloads
 runcpu --config=myconfig.x86.cfg --define build_ncpus=$(nproc) --action=build all
+
+# remove the log files to avoid copying out large files
+rm -f /home/gem5/spec2017/result/*

--- a/docs/disks/spec2017/install-spec2017.sh
+++ b/docs/disks/spec2017/install-spec2017.sh
@@ -20,5 +20,9 @@ sed -i "s/\/opt\/rh\/devtoolset-7\/root\/usr/\/usr/g" /home/gem5/spec2017/config
 # Use sed command to remove the march=native flag when compiling
 sed -i "s/-march=native//g" /home/gem5/spec2017/config/myconfig.x86.cfg
 
+# Prevent runcpu from calling sysinfo
+# https://www.spec.org/cpu2017/Docs/config.html#sysinfo-program
+sed -i "s/command_add_redirect = 1/sysinfo_program =\ncommand_add_redirect = 1/g" /home/gem5/spec2017/config/myconfig.x86.cfg
+
 # build all SPEC workloads
 runcpu --config=myconfig.x86.cfg --define build_ncpus=$(nproc) --action=build all

--- a/docs/disks/spec2017/install-spec2017.sh
+++ b/docs/disks/spec2017/install-spec2017.sh
@@ -14,18 +14,24 @@ rm -f /home/gem5/cpu2017-1.1.0.iso
 # use the example config as the template 
 cp /home/gem5/spec2017/config/Example-gcc-linux-x86.cfg /home/gem5/spec2017/config/myconfig.x86.cfg
 
-# Use sed command to replace the default gcc_dir
+# use sed command to replace the default gcc_dir
 sed -i "s/\/opt\/rh\/devtoolset-7\/root\/usr/\/usr/g" /home/gem5/spec2017/config/myconfig.x86.cfg
 
-# Use sed command to remove the march=native flag when compiling
+# use sed command to remove the march=native flag when compiling
+# this is necessary as the packer script runs in kvm mode, so the details of the CPU will be that of the host CPU
+# the -march=native flag is removed to avoid compiling instructions that gem5 does not support
+# finetuning flags should be manually added
 sed -i "s/-march=native//g" /home/gem5/spec2017/config/myconfig.x86.cfg
 
-# Prevent runcpu from calling sysinfo
+# prevent runcpu from calling sysinfo
 # https://www.spec.org/cpu2017/Docs/config.html#sysinfo-program
+# this is necessary as the sysinfo program queries the details of the system's CPU
+# the query causes gem5 runtime error
 sed -i "s/command_add_redirect = 1/sysinfo_program =\ncommand_add_redirect = 1/g" /home/gem5/spec2017/config/myconfig.x86.cfg
 
 # build all SPEC workloads
 runcpu --config=myconfig.x86.cfg --define build_ncpus=$(nproc) --action=build all
 
-# remove the log files to avoid copying out large files
+# the above building process will produce a large log file
+# this command removes the log files to avoid copying out large files unnecessarily
 rm -f /home/gem5/spec2017/result/*


### PR DESCRIPTION
gem5 does not work when SPEC 2017 calls sysinfo. This commit updates the SPEC config so that it turns sysinfo off. Verifying whether it works.