### PR TITLE
Update the celery related doc

### DIFF
--- a/docs/boot-tutorial.md
+++ b/docs/boot-tutorial.md
@@ -189,12 +189,19 @@ If not already running/created, you can create a database using:
 ```sh
 `docker run -p 27017:27017 -v <absolute path to the created directory>:/data/db --name mongo-<some tag> -d mongo`
 ```
-in a newly created directory and run celery server using:
+in a newly created directory.
+
+If not already installed, install `RabbitMQ` on your system (before running celery) using:
+
+```sh
+apt-get install rabbitmq-server
+```
+
+Now, run celery server using:
 
 ```sh
 celery -E -A gem5art.tasks.celery worker --autoscale=[number of workers],0
 ```
-
 
 ## Creating a launch script
 Finally, we will create a launch script with the name launch_boot_tests.py, which will be responsible for registering the artifacts to be used and then launching gem5 jobs.

--- a/docs/microbench-tutorial.md
+++ b/docs/microbench-tutorial.md
@@ -134,7 +134,15 @@ If not already running/created, you can create a database using:
 ```sh
 `docker run -p 27017:27017 -v <absolute path to the created directory>:/data/db --name mongo-<some tag> -d mongo`
 ```
-in a newly created directory and run celery server using:
+in a newly created directory.
+
+If not already installed, install `RabbitMQ` on your system (before running celery) using:
+
+```sh
+apt-get install rabbitmq-server
+```
+
+Now, run celery server using:
 
 ```sh
 celery -E -A gem5art.tasks.celery worker --autoscale=[number of workers],0

--- a/docs/npb-tutorial.md
+++ b/docs/npb-tutorial.md
@@ -364,11 +364,20 @@ If not already running/created, you can create a database using:
 ```sh
 `docker run -p 27017:27017 -v <absolute path to the created directory>:/data/db --name mongo-<some tag> -d mongo`
 ```
-in a newly created directory and run celery server using:
+in a newly created directory.
+
+If not already installed, install `RabbitMQ` on your system (before running celery) using:
+
+```sh
+apt-get install rabbitmq-server
+```
+
+Now, run celery server using:
 
 ```sh
 celery -E -A gem5art.tasks.celery worker --autoscale=[number of workers],0
 ```
+
 
 
 ## Creating a launch script

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -20,6 +20,13 @@ It will autoscale from 0 to desired number of workers.
 
 <!--Then, you can write a script (e.g., `launch_tests.py`) which will first create all of the required artifacts and will call the `run` task defined in gem5art.-->
 
+Celery relies on a message broker `RabbitMQ` for communication between the client and workers.
+If not already installed, you need to install `RabbitMQ` on your system (before running celery) using:
+
+```sh
+apt-get install rabbitmq-server
+```
+
 ## Monitoring Celery
 You can monitor the celery cluster doing the following:
 


### PR DESCRIPTION
This PR updates the documentation on how to start the celery server. Basically, RabbitMQ needs to be installed on a system for celery to work (it was missing in the documentation)