### PR TITLE
Pathlib update

### DIFF
--- a/artifact/gem5art/artifact/_artifactdb.py
+++ b/artifact/gem5art/artifact/_artifactdb.py
@@ -46,7 +46,7 @@ class ArtifactDB(ABC):
         pass
 
     @abstractmethod
-    def upload(self, key: UUID, path: str) -> None:
+    def upload(self, key: UUID, path: Path) -> None:
         """Upload the file at path to the database with _id of key"""
         pass
 
@@ -63,7 +63,7 @@ class ArtifactDB(ABC):
         pass
 
     @abstractmethod
-    def downloadFile(self, key: UUID, path: str) -> None:
+    def downloadFile(self, key: UUID, path: Path) -> None:
         """Download the file with the _id key to the path. Will overwrite the
         file if it currently exists."""
         pass

--- a/artifact/gem5art/artifact/_artifactdb.py
+++ b/artifact/gem5art/artifact/_artifactdb.py
@@ -30,6 +30,7 @@
 from abc import ABC, abstractmethod
 
 import gridfs # type: ignore
+from pathlib import Path
 from pymongo import MongoClient # type: ignore
 from typing import Any, Dict, Iterable, Union, Type
 from uuid import UUID
@@ -118,7 +119,7 @@ class ArtifactMongoDB(ArtifactDB):
         assert artifact['_id'] == key
         self.artifacts.insert_one(artifact)
 
-    def upload(self, key: UUID, path: str) -> None:
+    def upload(self, key: UUID, path: Path) -> None:
         """Upload the file at path to the database with _id of key"""
         with open(path, 'rb') as f:
             self.fs.upload_from_stream_with_id(key, path, f)
@@ -143,7 +144,7 @@ class ArtifactMongoDB(ArtifactDB):
             # This is a hash.
             return self.artifacts.find_one({'hash': key}, limit = 1)
 
-    def downloadFile(self, key: UUID, path: str) -> None:
+    def downloadFile(self, key: UUID, path: Path) -> None:
         """Download the file with the _id key to the path. Will overwrite the
         file if it currently exists."""
         with open(path, 'wb') as f:

--- a/artifact/gem5art/artifact/artifact.py
+++ b/artifact/gem5art/artifact/artifact.py
@@ -33,6 +33,7 @@
 import hashlib
 from inspect import cleandoc
 import os
+from pathlib import Path
 import subprocess
 import time
 from typing import Any, Dict, Iterator, List, Union
@@ -41,7 +42,7 @@ from uuid import UUID, uuid4
 from ._artifactdb import getDBConnection
 
 
-def getHash(path: str) -> str:
+def getHash(path: Path) -> str:
     """
     Returns an md5 hash for the file in self.path.
     """
@@ -55,16 +56,16 @@ def getHash(path: str) -> str:
 
     return md5.hexdigest()
 
-def getGit(path: str) -> Dict[str,str]:
+def getGit(path: Path) -> Dict[str,str]:
     """
     Returns dictionary with origin, current commit, and repo name for the
     base repository for `path`.
     An exception is generated if the repo is dirty or doesn't exist
     """
-    path = os.path.abspath(path)
+    path = path.resolve() # Make absolute
 
-    if os.path.isfile(path):
-        path = os.path.dirname(path)
+    if path.is_file():
+        path = path.parent
 
     command = ['git', 'status', '--porcelain', '--ignore-submodules',
                 '--untracked-files=no']
@@ -109,11 +110,11 @@ class Artifact:
     type: str
     documentation: str
     command: str
-    path: str
+    path: Path
     hash: str
     time: float
     git: Dict[str,str]
-    cwd: str
+    cwd: Path
     inputs: List['Artifact']
 
 
@@ -123,7 +124,7 @@ class Artifact:
                          name: str,
                          cwd: str,
                          typ: str,
-                         path: str,
+                         path: Union[str, Path],
                          documentation: str,
                          inputs: List['Artifact'] = []
                          ) -> 'Artifact':
@@ -150,19 +151,23 @@ class Artifact:
 
         data['time'] = time.time()
 
-        data['path'] = path
-        if os.path.isfile(path):
-            data['hash'] = getHash(path)
+        ppath = Path(path)
+        data['path'] = ppath
+        if ppath.is_file():
+            data['hash'] = getHash(ppath)
             data['git'] = {}
-        elif os.path.isdir(path):
-            data['git'] = getGit(path)
+        elif ppath.is_dir():
+            data['git'] = getGit(ppath)
             data['hash'] = data['git']['hash']
         else:
-            raise Exception("Path {} doesn't exist".format(path))
+            raise Exception("Path {} doesn't exist".format(ppath))
 
-        data['cwd'] = cwd
-        if not os.path.exists(cwd):
-            raise Exception("cwd {} doesn't exits.".format(cwd))
+        pcwd = Path(cwd)
+        data['cwd'] = pcwd
+        if not pcwd.exists():
+            raise Exception("cwd {} doesn't exist.".format(pcwd))
+        if not pcwd.is_dir():
+            raise Exception("cwd {} is not a directory".format(pcwd))
 
         data['inputs'] = [i._id for i in inputs]
 
@@ -182,7 +187,7 @@ class Artifact:
             _db.put(self._id, self._getSerializable())
 
             # Upload the file if there is one.
-            if os.path.isfile(self.path):
+            if self.path.is_file():
                 _db.upload(self._id, self.path)
 
         return self
@@ -206,11 +211,11 @@ class Artifact:
         self.type = other['type']
         self.documentation = other['documentation']
         self.command = other['command']
-        self.path = other['path']
+        self.path = Path(other['path'])
         self.hash = other['hash']
         assert isinstance(other['git'], dict)
         self.git = other['git']
-        self.cwd = other['cwd']
+        self.cwd = Path(other['cwd'])
         self.inputs = [Artifact(i) for i in other['inputs']]
 
     def __str__(self) -> str:

--- a/artifact/tests/test_artifact.py
+++ b/artifact/tests/test_artifact.py
@@ -212,7 +212,7 @@ class TestRegisterArtifact(unittest.TestCase):
             'command': ['vim test_artifact.py'],
             'path': './tests/test_artifact.py',
             'hash': hashlib.md5().hexdigest(),
-            'git': artifact.artifact.getGit('.'),
+            'git': artifact.artifact.getGit(Path('.')),
             'cwd': '/',
             'inputs': [],
         })

--- a/artifact/tests/test_artifact.py
+++ b/artifact/tests/test_artifact.py
@@ -30,7 +30,7 @@
 """Tests for the Artifact object and associated functions"""
 
 import hashlib
-from os.path import exists
+from pathlib import Path
 import unittest
 from uuid import uuid4, UUID
 import sys
@@ -83,12 +83,12 @@ _db = getDBConnection(typ = MockDB)
 
 class TestGit(unittest.TestCase):
     def test_keys(self):
-        git = artifact.artifact.getGit('.')
+        git = artifact.artifact.getGit(Path('.'))
         self.assertSetEqual(set(git.keys()), set(['origin', 'hash', 'name']),
                             "git keys wrong")
 
     def test_origin(self):
-        git = artifact.artifact.getGit('.')
+        git = artifact.artifact.getGit(Path('.'))
         self.assertTrue(git['origin'].endswith('gem5art'),
                         "Origin should end with gem5art")
 
@@ -103,14 +103,14 @@ class TestArtifact(unittest.TestCase):
             'command': ['ls', '-l'],
             'path': '/',
             'hash': hashlib.md5().hexdigest(),
-            'git': artifact.artifact.getGit('.'),
+            'git': artifact.artifact.getGit(Path('.')),
             'cwd': '/',
             'inputs': [],
         })
 
     def test_dirs(self):
-        self.assertTrue(exists(self.artifact.cwd))
-        self.assertTrue(exists(self.artifact.path))
+        self.assertTrue(self.artifact.cwd.exists())
+        self.assertTrue(self.artifact.path.exists())
 
 class TestArtifactSimilarity(unittest.TestCase):
 
@@ -123,7 +123,7 @@ class TestArtifactSimilarity(unittest.TestCase):
             'command': ['ls', '-l'],
             'path': '/',
             'hash': hashlib.md5().hexdigest(),
-            'git': artifact.artifact.getGit('.'),
+            'git': artifact.artifact.getGit(Path('.')),
             'cwd': '/',
             'inputs': [],
         })
@@ -136,7 +136,7 @@ class TestArtifactSimilarity(unittest.TestCase):
             'command': ['ls', '-l'],
             'path': '/',
             'hash': hashlib.md5().hexdigest(),
-            'git': artifact.artifact.getGit('.'),
+            'git': artifact.artifact.getGit(Path('.')),
             'cwd': '/',
             'inputs': [],
         })
@@ -149,7 +149,7 @@ class TestArtifactSimilarity(unittest.TestCase):
             'command': ['ls', '-l'],
             'path': '/',
             'hash': self.artifactA.hash,
-            'git': artifact.artifact.getGit('.'),
+            'git': artifact.artifact.getGit(Path('.')),
             'cwd': '/',
             'inputs': [],
         })
@@ -162,7 +162,7 @@ class TestArtifactSimilarity(unittest.TestCase):
             'command': ['ls', '-l'],
             'path': '/',
             'hash': hashlib.md5().hexdigest(),
-            'git': artifact.artifact.getGit('.'),
+            'git': artifact.artifact.getGit(Path('.')),
             'cwd': '/',
             'inputs': [],
         })

--- a/run/.gitignore
+++ b/run/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/run/tests/test_run.py
+++ b/run/tests/test_run.py
@@ -30,7 +30,7 @@
 """Tests for gem5Run object"""
 
 import hashlib
-from os.path import exists
+from pathlib import Path
 import os
 import unittest
 from uuid import uuid4
@@ -49,7 +49,7 @@ class TestSERun(unittest.TestCase):
             'command': 'scons build/X86/gem5.opt',
             'path': '/',
             'hash': hashlib.md5().hexdigest(),
-            'git': artifact.getGit('.'),
+            'git': artifact.getGit(Path('.')),
             'cwd': '/',
             'inputs': [],
             })
@@ -62,7 +62,7 @@ class TestSERun(unittest.TestCase):
             'command': 'git clone something',
             'path': '/',
             'hash': hashlib.md5().hexdigest(),
-            'git': artifact.getGit('.'),
+            'git': artifact.getGit(Path('.')),
             'cwd': '/',
             'inputs': [],
             })
@@ -75,7 +75,7 @@ class TestSERun(unittest.TestCase):
             'command': 'git clone something',
             'path': '/',
             'hash': hashlib.md5().hexdigest(),
-            'git': artifact.getGit('.'),
+            'git': artifact.getGit(Path('.')),
             'cwd': '/',
             'inputs': [],
             })
@@ -93,11 +93,11 @@ class TestSERun(unittest.TestCase):
 
     def test_out_dir(self):
         relative_outdir = 'results/run_test/out'
-        self.assertEqual(self.run.outdir[-len(relative_outdir):],
-                relative_outdir)
+        self.assertEqual(self.run.outdir.relative_to(Path('.').resolve()),
+                         Path(relative_outdir))
 
-        self.assertIs(self.run.outdir[0], '/',
-                     "outdir should be absolute directory")
+        self.assertTrue(self.run.outdir.is_absolute(),
+                        "outdir should be absolute directory")
 
     def test_command(self):
         self.assertEqual(self.run.command,


### PR DESCRIPTION
The commits in this PR should be merged at the same time.

I ran the unittests, but I didn't run anything else. @takekoputa, I wasn't 100% on the change to the relative paths in the zips. I tested it manually from the python REPL and I got a zipfile similar to what I think we expect. I see the following when I use one of your results directories. Let me know if this isn't what I should see.

```
$ unzip -l test.zip
Archive:  test.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      829  2019-12-09 13:42   401.bzip2/simout
  1053053  2019-12-09 13:42   401.bzip2/stats.txt
    57366  2019-12-09 13:42   401.bzip2/config.ini
    23039  2019-12-09 13:42   401.bzip2/system.pc.com_1.device
   149623  2019-12-09 13:42   401.bzip2/config.json
        0  2019-12-09 13:42   401.bzip2/speclogs/
   114350  2019-12-09 13:42   401.bzip2/config.dot
    36527  2019-12-09 13:42   401.bzip2/config.dot.pdf
     1555  2019-12-09 13:42   401.bzip2/info.json
     4871  2019-12-09 13:42   401.bzip2/simerr
       83  2019-12-09 13:42   401.bzip2/run_401.bzip2_test
   143626  2019-12-09 13:42   401.bzip2/config.dot.svg
     8618  2019-12-09 13:42   401.bzip2/speclogs/CINT2006.002.test.rsf
    16288  2019-12-09 13:42   401.bzip2/speclogs/CINT2006.002.test.flags.html
  2547358  2019-12-09 13:42   401.bzip2/speclogs/CPU2006.001.log
        4  2019-12-09 13:42   401.bzip2/speclogs/CPU2006.lock
     4129  2019-12-09 13:42   401.bzip2/speclogs/CPU2006.002.log
    62670  2019-12-09 13:42   401.bzip2/speclogs/CINT2006.002.test.pdf
     8385  2019-12-09 13:42   401.bzip2/speclogs/CINT2006.002.test.txt
---------                     -------
  4232374                     19 files

```