### PR TITLE
Generalize the ArtifactDB object

### DIFF
--- a/artifact/gem5art/artifact/__init__.py
+++ b/artifact/gem5art/artifact/__init__.py
@@ -31,4 +31,4 @@
 
 from .artifact import Artifact
 from .artifact import getByName, getDiskImages, getLinuxBinaries, getgem5Binaries
-from ._artifactdb import ArtifactDB, getDBConnection
+from ._artifactdb import getDBConnection

--- a/artifact/gem5art/artifact/artifact.py
+++ b/artifact/gem5art/artifact/artifact.py
@@ -272,8 +272,12 @@ class Artifact:
     def __hash__(self) -> int:
         return self._id.int
 
-def _getByType(typ: str, limit: int) -> Iterator[Artifact]:
-    data = _db.artifacts.find({'type':typ}, limit=limit)
+def _getByType(typ: str, limit: int = 0) -> Iterator[Artifact]:
+    """Returns a generator of Artifacts with matching `type` from the db.
+
+    Limit specifies the maximum number of results to return.
+    """
+    data = _db.searchByType(typ, limit=limit)
 
     for d in data:
         yield Artifact(d)
@@ -308,7 +312,7 @@ def getByName(name: str, limit: int = 0) -> Iterator[Artifact]:
 
     Limit specifies the maximum number of results to return.
     """
-    data = _db.artifacts.find({'name': name}, limit=limit)
+    data = _db.searchByName(name, limit=limit)
 
     for d in data:
         yield Artifact(d)

--- a/docs/main-doc/artifacts.md
+++ b/docs/main-doc/artifacts.md
@@ -150,7 +150,7 @@ Python 3.6.8 (default, Oct  7 2019, 12:59:55)
 [GCC 8.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>> from gem5art.artifact import *
->>> db = ArtifactDB()
+>>> db = getDBConnection()
 >>> for i in getDiskImages(limit=2): print(i)
 ...
 ubuntu

--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -48,7 +48,7 @@ import zipfile
 from gem5art import artifact
 from gem5art.artifact import Artifact
 
-_db: artifact.ArtifactDB = artifact.getDBConnection()
+_db: artifact._artifactdb.ArtifactDB = artifact.getDBConnection()
 
 class gem5Run:
     """
@@ -513,11 +513,11 @@ def getRuns(fs_only: bool = False, limit: int = 0) -> Iterable[gem5Run]:
     """
 
     if not fs_only:
-        runs = _db.artifacts.find({'type':'gem5 run'}, limit=limit)
+        runs = _db.searchByType('gem5 run', limit=limit)
         for run in runs:
             yield gem5Run.loadFromDict(run)
 
-    fsruns = _db.artifacts.find({'type':'gem5 run fs'}, limit=limit)
+    fsruns = _db.searchByType('gem5 run fs', limit=limit)
     for run in fsruns:
         yield gem5Run.loadFromDict(run)
 
@@ -532,13 +532,12 @@ def getRunsByName(name: str, fs_only: bool = False,
     """
 
     if not fs_only:
-        seruns = _db.artifacts.find({'type':'gem5 run', 'name': name},
-                                    limit=limit)
+        seruns = _db.searchByNameType(name, 'gem5 run', limit=limit)
         for run in seruns:
             yield gem5Run.loadFromDict(run)
 
-    fsruns = _db.artifacts.find({'type':'gem5 run fs', 'name': name},
-                                limit=limit)
+    fsruns = _db.searchByNameType(name, 'gem5 run fs', limit=limit)
+
     for run in fsruns:
         yield gem5Run.loadFromDict(run)
 
@@ -553,14 +552,12 @@ def getRunsByNameLike(name: str, fs_only: bool = False,
     """
 
     if not fs_only:
-        seruns = _db.artifacts.find({'type':'gem5 run',
-                                     'name': {'$regex': name}},
-                                    limit=limit)
+        seruns = _db.searchByLikeNameType(name, 'gem5 run', limit=limit)
+
         for run in seruns:
             yield gem5Run.loadFromDict(run)
 
-    fsruns = _db.artifacts.find({'type':'gem5 run fs',
-                                 'name': {'$regex': name}},
-                                limit=limit)
+    fsruns = _db.searchByLikeNameType(name, 'gem5 run fs', limit=limit)
+
     for run in fsruns:
         yield gem5Run.loadFromDict(run)


### PR DESCRIPTION
This puts on the path to being able to implement other database types
(e.g., a mock database as mentioned in DARCHR-115).

This is working towards DARCHR-121.

This patch makes ArtifactDB fully virtual and removes it from the global
namespace exported by Artifact.

`getDBConnection` now is correctly implemented as a singleton factory.

It also adds a searchByName and searchByType functions to the abstract
DB and implementes them in the MongoDB version to move the
mongo-specific code from artifact.

The documentation is also updated to always use getDBConnection.

Signed-off-by: Jason Lowe-Power <jason@lowepower.com>