### PR TITLE
Fix getRuns* functions in gem5art.run

### DIFF
--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -532,12 +532,12 @@ def getRunsByName(name: str, fs_only: bool = False,
     """
 
     if not fs_only:
-        seruns = _db.artifacts.find({'type:':'gem5 run', 'name': name},
+        seruns = _db.artifacts.find({'type':'gem5 run', 'name': name},
                                     limit=limit)
         for run in seruns:
             yield gem5Run.loadFromDict(run)
 
-    fsruns = _db.artifacts.find({'type:':'gem5 run fs', 'name': name},
+    fsruns = _db.artifacts.find({'type':'gem5 run fs', 'name': name},
                                 limit=limit)
     for run in fsruns:
         yield gem5Run.loadFromDict(run)
@@ -553,13 +553,13 @@ def getRunsByNameLike(name: str, fs_only: bool = False,
     """
 
     if not fs_only:
-        seruns = _db.artifacts.find({'type:':'gem5 run',
+        seruns = _db.artifacts.find({'type':'gem5 run',
                                      'name': {'$regex': '/{}/'.format(name)}},
                                     limit=limit)
         for run in seruns:
             yield gem5Run.loadFromDict(run)
 
-    fsruns = _db.artifacts.find({'type:':'gem5 run fs',
+    fsruns = _db.artifacts.find({'type':'gem5 run fs',
                                  'name': {'$regex': '/{}/'.format(name)}},
                                 limit=limit)
     for run in fsruns:

--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -554,13 +554,13 @@ def getRunsByNameLike(name: str, fs_only: bool = False,
 
     if not fs_only:
         seruns = _db.artifacts.find({'type':'gem5 run',
-                                     'name': {'$regex': '/{}/'.format(name)}},
+                                     'name': {'$regex': name}},
                                     limit=limit)
         for run in seruns:
             yield gem5Run.loadFromDict(run)
 
     fsruns = _db.artifacts.find({'type':'gem5 run fs',
-                                 'name': {'$regex': '/{}/'.format(name)}},
+                                 'name': {'$regex': name}},
                                 limit=limit)
     for run in fsruns:
         yield gem5Run.loadFromDict(run)


### PR DESCRIPTION
Corrected typos in the queries that cause getRunsByName and getRunsByNameLike to return empty results.