### PR TITLE
Fix ArtifactMongoDB.upload() function

### DIFF
--- a/artifact/gem5art/artifact/_artifactdb.py
+++ b/artifact/gem5art/artifact/_artifactdb.py
@@ -122,7 +122,7 @@ class ArtifactMongoDB(ArtifactDB):
     def upload(self, key: UUID, path: Path) -> None:
         """Upload the file at path to the database with _id of key"""
         with open(path, 'rb') as f:
-            self.fs.upload_from_stream_with_id(key, path, f)
+            self.fs.upload_from_stream_with_id(key, str(path), f)
 
     def __contains__(self, key: Union[UUID, str]) -> bool:
         """Key can be a UUID or a string. Returns true if item in DB"""


### PR DESCRIPTION
gridfs.GridFSBucket.upload_from_stream_with_id() requires the second parameter (filename) to be an str. Currently, we pass a Pass object to the parameter, which causes an error when gem5art uploads artifacts. This commit converts the Path object to str.

If anybody can reproduce this error (https://gem5.atlassian.net/browse/DARCHR-213) then we should merge this fix.