### PR TITLE
Uploading artifact before registering artifact

### DIFF
--- a/artifact/gem5art/artifact/artifact.py
+++ b/artifact/gem5art/artifact/artifact.py
@@ -182,13 +182,14 @@ class Artifact:
         else:
             data['_id'] = uuid4()
 
+            # Upload the file if there is one.
+            if self.path.is_file():
+                _db.upload(self._id, self.path)
+
             # Now that we have a complete object, construct it
             self = cls(data)
             _db.put(self._id, self._getSerializable())
 
-            # Upload the file if there is one.
-            if self.path.is_file():
-                _db.upload(self._id, self.path)
 
         return self
 

--- a/artifact/gem5art/artifact/artifact.py
+++ b/artifact/gem5art/artifact/artifact.py
@@ -182,12 +182,14 @@ class Artifact:
         else:
             data['_id'] = uuid4()
 
+            # Now that we have a complete object, construct it
+            self = cls(data)
+
             # Upload the file if there is one.
             if self.path.is_file():
                 _db.upload(self._id, self.path)
 
-            # Now that we have a complete object, construct it
-            self = cls(data)
+            # Putting the artifact to the database
             _db.put(self._id, self._getSerializable())
 
 


### PR DESCRIPTION
Currently, we register an artifact with the database before it is being uploaded. This leads to the case where the artifact is failed to be uploaded, and the file won't be uploaded in later runs, since it is registered to the database. This would cause an issue if we want to retrieve the file later (e.g. querying `result` artifacts).

This commit fixes that by uploading the file first, and registers the corresponding artifact later.