### PR TITLE
Add a print statement to indicate when run results are stored in db

### DIFF
--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -485,6 +485,8 @@ class gem5Run:
         # Store current gem5 run in the database
         _db.put(self._id, self._getSerializable())
 
+        print("Done storing the results of {}".format(' '.join(self.command)))
+
     def saveResults(self) -> None:
         """Zip up the output directory and store the results in the database.
         """


### PR DESCRIPTION
This is a small change to add a print statement after the run is finished and the run object + results are stored in the database. I think, this will help to figure out when something has gone wrong. 