### PR TITLE
gem5art: Edited the microbenchmark tutorial for clarity

### DIFF
--- a/docs/tutorials/microbench-tutorial.md
+++ b/docs/tutorials/microbench-tutorial.md
@@ -1,6 +1,7 @@
 ---
 Authors:
   - Ayaz Akram
+  - Nadia Etemadi
 ---
 
 # Tutorial: Run Microbenchmarks with gem5
@@ -24,7 +25,7 @@ This tutorial follows the following directory structure:
 
 
 ## Setting up the environment
-First, we need to create the main directory named micro-tests (from where we will run everything) and turn it into a git repository we did in the previous tutorials.
+First, we need to create the main directory named micro-tests (from where we will run everything) and turn it into a git repository like we did in the previous tutorials.
 Next, add a git remote to this repo pointing to a remote location where we want this repo to be hosted.
 
 ```sh
@@ -34,7 +35,7 @@ git init
 git remote add origin https://your-remote-add/micro-tests.git
 ```
 
-We also need to add a .gitignore file in our git repo, to not track files we don't care about:
+We also need to add a .gitignore file in our git repo to leave unnecessary files untracked:
 
 ```
 *.pyc
@@ -45,12 +46,14 @@ gem5
 venv
 ```
 
-Next, we will create a virtual environment before using gem5art
+Next, we will create a virtual python3 environment before using gem5art.
 
 ```sh
 virtualenv -p python3 venv
 source venv/bin/activate
 ```
+This virtual environment needs to be running in order to run experiments with gem5art.
+You can deactivate the environment at any time with the command `deactivate`.
 
 gem5art can be installed (if not already) using pip:
 
@@ -60,7 +63,7 @@ pip install gem5art-artifact gem5art-run gem5art-tasks
 
 ## Build gem5
 
-First clone gem5:
+First clone gem5 in your micro-tests repo:
 
 ```sh
 git clone https://gem5.googlesource.com/public/gem5
@@ -68,10 +71,10 @@ cd gem5
 ```
 
 Before building gem5, we need to apply a [patch](https://github.com/darchr/gem5/commit/38d07ab0251ea8f5181abc97a534bb60157b2b5d) to the source repo.
-Basically, (as you will later see), we will run gem5 with various memory configs.
+As you will later see, we will run gem5 with various memory configs.
 **Inf** (SimpleMemory with 0ns latency) and **SingleCycle** (SimpleMemory with 1ns latency) do not use any caches.
-Therefore, to implement cacheless SimpleMemory we need to add support of vector port in SimpleMemory.
-This becomes necessary as we need to connect cpu's icache and dcache ports to mem_ctrl port (a vector port).
+Therefore, to implement cacheless SimpleMemory, we need to add support of vector ports in SimpleMemory by applying this patch.
+This becomes necessary as we need to connect cpu's icache and dcache ports to the mem_ctrl port (a vector port).
 You can download and apply the patch as follows:
 
 ```sh
@@ -79,7 +82,7 @@ wget https://github.com/darchr/gem5/commit/f0a358ee08aba1563c7b5277866095b4cbb7c
 git am f0a358ee08aba1563c7b5277866095b4cbb7c36d.patch --reject
 ```
 
-Now, to build gem5:
+Now, build gem5:
 
 ```sh
 scons build/X86/gem5.opt -j8
@@ -92,22 +95,22 @@ Download the microbenchmarks:
 git clone https://github.com/darchr/microbench.git
 ```
 
-Commit the source of microbenchmarks to the micro-tests repo (so that the current version of microbenchmarks becomes a part of the micro-tests reposiotry).
+Commit the source of microbenchmarks to the micro-tests repo, so that the current version of the microbenchmarks repo becomes a part of the micro-tests repository.
 
 ```sh
 git add microbench/
 git commit -m "Add microbenchmarks"
 ```
 
-compile the benchmarks:
+Compile the benchmarks:
 
 ```sh
 cd microbench
 make
 ```
 
-By default, these microbenchmarks are compiled for x86 ISA (which will be our focus in this tutorial).
-You can add ARM or RISCV to the make command (as shown below) to compile these benchmarks for ARM and RISC V ISAs.
+By default, these microbenchmarks are compiled for the x86 ISA, which will be our focus in this tutorial.
+You can use the following commands to compile these benchmarks for ARM and RISC-V ISAs if you wish to work with them.
 
 ```sh
 make ARM
@@ -117,7 +120,7 @@ make RISCV
 
 ## gem5 run scripts
 
-Now, we will add the gem5 run and configuration scripts to a new folder named configs-micro-tests.
+Now, we will add the gem5 run and configuration scripts to a new folder named `configs-micro-tests`.
 Get the run script named run_micro.py from [here](https://github.com/darchr/gem5art/blob/master/docs/gem5-configs/configs-micro-tests/run_micro.py), and other system configuration file from
 [here](https://github.com/darchr/gem5art/blob/master/docs/gem5-configs/configs-micro-tests/system.py).
 The run script (run_micro.py) takes the following arguments:
@@ -129,7 +132,7 @@ The run script (run_micro.py) takes the following arguments:
 
 ## Database and Celery Server
 
-If not already running/created, you can create a database using:
+If not already running or created, you can create a database using:
 
 ```sh
 `docker run -p 27017:27017 -v <absolute path to the created directory>:/data/db --name mongo-<some tag> -d mongo`
@@ -142,16 +145,16 @@ If not already installed, install `RabbitMQ` on your system (before running cele
 apt-get install rabbitmq-server
 ```
 
-Now, run celery server using:
+Now, run the celery server using:
 
 ```sh
 celery -E -A gem5art.tasks.celery worker --autoscale=[number of workers],0
 ```
 
 ## Creating a launch script
-Next, we will create a launch script with the name launch_micro_tests.py, which will register the artifacts to be used and will start gem5 jobs.
+Next, we will create a launch script with the name `launch_micro_tests.py`, which will register the artifacts to be used and will start gem5 jobs.
 
-Like, we did in previous tutorials, the first step is to import the required modules and classes:
+Like we did in previous tutorials, the first step is to import the required modules and classes:
 
 ```python
 import os
@@ -201,8 +204,8 @@ gem5_binary = Artifact.registerArtifact(
 
 The number of artifacts is less than what we had to use in previous (full-system) tutorials ([boot](boot-tutorial.md), [npb](npb-tutorial.md)), as expected.
 
-Now to run the benchmarks, we will iterate through possible cpu types, memory types and all of the microbenchmarks from microbench/ folder.
-We will also register an artifact for each microbenchmark:
+Now to run the benchmarks, we will iterate through possible cpu types, memory types and all of the microbenchmarks from the microbench repository.
+We will also register an artifact for each microbenchmark. If you want to run certain benchmarks, you can indicate which ones in the `bm_list` array.
 
 ```python
 
@@ -245,18 +248,18 @@ if __name__ == "__main__":
                     'results/X86/run_micro/{}/{}/{}'.format(bm,cpu,mem),
                     gem5_binary,gem5_repo,experiments_repo,
                     cpu,mem,os.path.join('microbench',bm,'bench.X86'))
-                run_gem5_instance.apply_async((run, os.getcwd()))
+                run.run()
 
 ```
 
-Note that, in contrast to previous tutorials ([boot](boot-tutorial.md), [npb](npb-tutorial.md)), we are using createSERun here as we want to run gem5 in SE mode.
+Note that, in contrast to previous tutorials ([boot](boot-tutorial.md), [npb](npb-tutorial.md)), we are using createSERun here, as we want to run gem5 in SE mode.
 The details of the arguments needed by `createSERun()` can be found [here](../main-doc/run.html#gem5art.run.gem5Run.createSERun)).
-Full launch script is available [here](https://github.com/darchr/gem5art/blob/master/docs/launch-scripts/launch_micro_tests.py).
+The full launch script is available [here](https://github.com/darchr/gem5art/blob/master/docs/launch-scripts/launch_micro_tests.py).
 
-Once you run this launch script (as shown below), your gem5 experiments to simulate execution of microbenchmarks on different cpu and memory types will start running.
+Once you run this launch script (as shown below), your microbenchmark experiments will start running, which will simulate execution of microbenchmarks on different cpu and memory types.
 
 ```python
 python launch_micro_tests.py
 ```
 
-Later, you can access the database to see the status of these jobs and optionally do further analysis.
+Later, you can access the database to see the status of these jobs and further analyze the results of your microbenchmark experiments. Happy experimenting!

--- a/docs/tutorials/microbench-tutorial.md
+++ b/docs/tutorials/microbench-tutorial.md
@@ -252,7 +252,7 @@ if __name__ == "__main__":
 
 ```
 
-Note that, in contrast to previous tutorials ([boot](boot-tutorial.md), [npb](npb-tutorial.md)), we are using createSERun here, as we want to run gem5 in SE mode.
+Note that, in contrast to previous tutorials ([boot](boot-tutorial.md), [npb](npb-tutorial.md)), we are using createSERun this time, as we want to run gem5 in SE mode.
 The details of the arguments needed by `createSERun()` can be found [here](../main-doc/run.html#gem5art.run.gem5Run.createSERun)).
 The full launch script is available [here](https://github.com/darchr/gem5art/blob/master/docs/launch-scripts/launch_micro_tests.py).
 


### PR DESCRIPTION
The tutorial on running microbenchmarks contained code that
was outdated and did not work with the current version
of gem5art. In addition, other edits were made for
clarity, such as specifying that the Python virtual
environment must always be running, as well as other
minor grammatical/syntactical edits.