### PR TITLE
run: don't fail if object missing from db

### DIFF
--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -293,7 +293,12 @@ class gem5Run:
         run.artifacts = []
         for k,v in d.items():
             if isinstance(v, UUID) and k != '_id':
-                a = Artifact(v)
+                try:
+                    a = Artifact(v)
+                except Exception:
+                    # UUID isn't found in the database. Insert a simple
+                    # dict with just an id and blank data instead
+                    a = {'_id': str(v), 'data':'???'}
                 setattr(run, k, a)
                 run.artifacts.append(a)
             else:


### PR DESCRIPTION
In loadFromDict, if there is an artifact that's not found in the
database, the current behavior is to raise an exception. This change
instead inserts a "placeholder" dictionary with the original UUID and a
note that the data can't be found. Currently, this function is only used
when extracting runs from the database.

Signed-off-by: Jason Lowe-Power <jason@lowepower.com>