### PR TITLE
Add ability to configure db connection

### DIFF
--- a/artifact/tests/test_artifact.py
+++ b/artifact/tests/test_artifact.py
@@ -45,7 +45,7 @@ class MockDB(ArtifactDB):
     This is a Mock DB,
     used to run unit tests
     """
-    def __init__(self):
+    def __init__(self, uri = ''):
         self.db = {}
         self.hashes = {}
 
@@ -74,12 +74,13 @@ class MockDB(ArtifactDB):
     def downloadFile(self, key, path):
         pass
 
+# Add the MockDB as a scheme
+artifact._artifactdb._db_schemes['mockdb'] = MockDB
 
 # This needs to be a global variable so
 # that this getDBConnection is the first
 # call to create a DB connection
-_db = getDBConnection(typ = MockDB)
-
+_db = getDBConnection('mockdb://')
 
 class TestGit(unittest.TestCase):
     def test_keys(self):


### PR DESCRIPTION
This change updates the db constructor to take a parameter to set up the
db connection. It also changes the interface for getDBConnection to take
a "URI" for the database connection. Right now, the only option is
MongoDB, but in the future, we can add flat files or other database
backends easily.

Signed-off-by: Jason Lowe-Power <jason@lowepower.com>