### PR TITLE
Fix UnicodeDecodingError while checking for kernel panic

### DIFF
--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -339,6 +339,14 @@ class gem5Run:
             except OSError:
                 return False
             try:
+                # There was a case where reading `term_path` resulted in a
+                # UnicodeDecodeError. It is known that the terminal output
+                # (content of 'system.pc.com_1.device') is written from a
+                # buffer from gem5, and when gem5 stops, the content of the
+                # buffer is stopped being copied to the file. The buffer is
+                # not flushed as well. So, it might be a case that the content
+                # of the `term_path` is corrupted as a Unicode character could
+                # be longer than a byte.
                 last = f.readlines()[-1].decode()
                 if 'Kernel panic' in last:
                     return True

--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -338,10 +338,13 @@ class gem5Run:
                 f.seek(-1000, os.SEEK_END)
             except OSError:
                 return False
-            last = f.readlines()[-1].decode()
-            if 'Kernel panic' in last:
-                return True
-            else:
+            try:
+                last = f.readlines()[-1].decode()
+                if 'Kernel panic' in last:
+                    return True
+                else:
+                    return False
+            except UnicodeDecodeError:
                 return False
 
     def _getSerializable(self) -> Dict[str, Union[str, UUID]]:


### PR DESCRIPTION
There were runs running into UnicodeDecodingError while gem5art checking for kernel panic in the terminal output.