### PR TITLE
Fix SPEC tutorial file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,8 +70,7 @@ Tutorials
    tutorials/boot-tutorial.md
    tutorials/npb-tutorial.md
    tutorials/microbench-tutorial.md
-   tutorials/spec2006-tutorial.md
-   tutorials/spec2017-tutorial.md
+   tutorials/spec-tutorial.md
    tutorials/parsec-tutorial.md
 
 Indices and tables


### PR DESCRIPTION
Spec tutorial doesn't show up in the readthedocs website because the filename was incorrect.