### PR TITLE
run: Removed redundant inputs from createFSRun and createSERun

### DIFF
--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -57,7 +57,7 @@ class gem5Run:
     hash: str
     type: str
     name: str
-    gem5_binary: Path
+    gem5_binary_path: Path
     run_script: Path
     gem5_artifact: Artifact
     gem5_git_artifact: Artifact
@@ -74,8 +74,8 @@ class gem5Run:
 
     outdir: Path
 
-    linux_binary: Path
-    disk_image: Path
+    linux_binary_path: Path
+    disk_image_path: Path
     linux_binary_artifact: Artifact
     disk_image_artifact: Artifact
 
@@ -114,7 +114,7 @@ class gem5Run:
         """
         run = cls()
         run.name = name
-        run.gem5_binary = gem5_artifact.path
+        run.gem5_binary_path = gem5_artifact.path
         run.run_script = run_script
         run.gem5_artifact = gem5_artifact
         run.gem5_git_artifact = gem5_git_artifact
@@ -130,7 +130,7 @@ class gem5Run:
         run.outdir = outdir.resolve()  # ensure this is absolute
 
         # Assumes **/<gem5_name>/gem5.<anything>
-        run.gem5_name = run.gem5_binary.parent.name
+        run.gem5_name = run.gem5_binary_path.parent.name
         # Assumes **/<script_name>.py
         run.script_name = run.run_script.stem
 
@@ -182,7 +182,7 @@ class gem5Run:
         a file `info.json` in the outdir which contains a serialized version
         of this class.
         """
-        
+
         run = cls._create(
             name,
             Path(run_script),
@@ -205,7 +205,7 @@ class gem5Run:
         run.string += " ".join(run.params)
 
         run.command = [
-            str(run.gem5_binary),
+            str(run.gem5_binary_path),
             "-re",
             f"--outdir={run.outdir}",
             str(run.run_script),
@@ -264,13 +264,13 @@ class gem5Run:
             timeout,
             check_failure
         )
-        run.linux_binary = Path(linux_binary_artifact.path)
-        run.disk_image = Path(disk_image_artifact.path)
+        run.linux_binary_path = Path(linux_binary_artifact.path)
+        run.disk_image_path = Path(disk_image_artifact.path)
         run.linux_binary_artifact = linux_binary_artifact
         run.disk_image_artifact = disk_image_artifact
 
         # Assumes **/<linux_name>
-        run.linux_name = run.linux_binary.name
+        run.linux_name = run.linux_binary_path.name
         # Assumes **/<disk_name>
         run.disk_name = disk_image_artifact.name
 
@@ -286,12 +286,12 @@ class gem5Run:
         run.string += f"{run.linux_name} {run.disk_name} "
         run.string += " ".join(run.params)
         run.command = [
-            str(run.gem5_binary),
+            str(run.gem5_binary_path),
             "-re",
             f"--outdir={run.outdir}",
             str(run.run_script),
-            str(run.linux_binary),
-            str(run.disk_image),
+            str(run.linux_binary_path),
+            str(run.disk_image_path),
         ]
         run.command += list(params)
 

--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -100,7 +100,6 @@ class gem5Run:
     def _create(
         cls,
         name: str,
-        gem5_binary: Path,
         run_script: Path,
         outdir: Path,
         gem5_artifact: Artifact,
@@ -115,7 +114,7 @@ class gem5Run:
         """
         run = cls()
         run.name = name
-        run.gem5_binary = gem5_binary
+        run.gem5_binary = gem5_artifact.path
         run.run_script = run_script
         run.gem5_artifact = gem5_artifact
         run.gem5_git_artifact = gem5_git_artifact
@@ -157,7 +156,6 @@ class gem5Run:
     def createSERun(
         cls,
         name: str,
-        gem5_binary: str,
         run_script: str,
         outdir: str,
         gem5_artifact: Artifact,
@@ -171,8 +169,7 @@ class gem5Run:
         name is the name of the run. The name is not necessarily unique. The
         name could be used to query the results of the run.
 
-        gem5_binary and run_script are the paths to the binary to run
-        and the script to pass to gem5. Full paths are better.
+        run_script is the path to the run script to pass to gem5.
 
         The artifact parameters (gem5_artifact, gem5_git_artifact, and
         run_script_git_artifact) are used to ensure this is reproducible run.
@@ -188,7 +185,6 @@ class gem5Run:
 
         run = cls._create(
             name,
-            Path(gem5_binary),
             Path(run_script),
             Path(outdir),
             gem5_artifact,
@@ -229,14 +225,11 @@ class gem5Run:
     def createFSRun(
         cls,
         name: str,
-        gem5_binary: str,
         run_script: str,
         outdir: str,
         gem5_artifact: Artifact,
         gem5_git_artifact: Artifact,
         run_script_git_artifact: Artifact,
-        linux_binary: str,
-        disk_image: str,
         linux_binary_artifact: Artifact,
         disk_image_artifact: Artifact,
         *params: str,
@@ -247,11 +240,7 @@ class gem5Run:
         name is the name of the run. The name is not necessarily unique. The
         name could be used to query the results of the run.
 
-        gem5_binary and run_script are the paths to the binary to run
-        and the script to pass to gem5.
-
-        The linux_binary is the kernel to run and the disk_image is the path
-        to the disk image to use.
+        run_script is the path to the run script to pass to gem5.
 
         Further parameters can be passed via extra arguments. These
         parameters will be passed in order to the gem5 run script.
@@ -264,10 +253,8 @@ class gem5Run:
         a file `info.json` in the outdir which contains a serialized version
         of this class.
         """
-
         run = cls._create(
             name,
-            Path(gem5_binary),
             Path(run_script),
             Path(outdir),
             gem5_artifact,
@@ -277,15 +264,15 @@ class gem5Run:
             timeout,
             check_failure
         )
-        run.linux_binary = Path(linux_binary)
-        run.disk_image = Path(disk_image)
+        run.linux_binary = Path(linux_binary_artifact.path)
+        run.disk_image = Path(disk_image_artifact.path)
         run.linux_binary_artifact = linux_binary_artifact
         run.disk_image_artifact = disk_image_artifact
 
         # Assumes **/<linux_name>
         run.linux_name = run.linux_binary.name
         # Assumes **/<disk_name>
-        run.disk_name = run.disk_image.name
+        run.disk_name = disk_image_artifact.name
 
         run.artifacts = [
             gem5_artifact,
@@ -298,7 +285,6 @@ class gem5Run:
         run.string = f"{run.gem5_name} {run.script_name} "
         run.string += f"{run.linux_name} {run.disk_name} "
         run.string += " ".join(run.params)
-
         run.command = [
             str(run.gem5_binary),
             "-re",
@@ -415,7 +401,8 @@ class gem5Run:
         del d["artifacts"]
 
         # Doesn't make sense to serialize the user-specified fail function
-        del d["check_failure"]
+        if 'check_failure' in d.keys():
+            del d["check_failure"]
 
         # Replace the artifacts with their UUIDs
         for k, v in d.items():

--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -182,7 +182,7 @@ class gem5Run:
         a file `info.json` in the outdir which contains a serialized version
         of this class.
         """
-        print(name, run_script, outdir, gem5_artifact, gem5_git_artifact, run_script_git_artifact, params)
+        
         run = cls._create(
             name,
             Path(run_script),

--- a/run/gem5art/run.py
+++ b/run/gem5art/run.py
@@ -182,7 +182,7 @@ class gem5Run:
         a file `info.json` in the outdir which contains a serialized version
         of this class.
         """
-
+        print(name, run_script, outdir, gem5_artifact, gem5_git_artifact, run_script_git_artifact, params)
         run = cls._create(
             name,
             Path(run_script),

--- a/run/tests/test_run.py
+++ b/run/tests/test_run.py
@@ -44,7 +44,7 @@ class TestSERun(unittest.TestCase):
             'type': 'test-binary',
             'documentation': "This is a description of gem5 artifact",
             'command': 'scons build/X86/gem5.opt',
-            'path': '/',
+            'path': 'gem5/build/X86/gem5.opt',
             'hash': hashlib.md5().hexdigest(),
             'git': artifact.getGit(Path('.')),
             'cwd': '/',
@@ -79,10 +79,9 @@ class TestSERun(unittest.TestCase):
 
         self.run = gem5Run.createSERun(
 		'test SE run',
-		'gem5/build/X86/gem5.opt',
 		'configs-tests/run_test.py',
 		'results/run_test/out',
-                self.gem5art,
+        self.gem5art,
 		self.gem5gitart,
 		self.runscptart,
 		'extra','params'

--- a/run/tests/test_run.py
+++ b/run/tests/test_run.py
@@ -81,7 +81,7 @@ class TestSERun(unittest.TestCase):
 		'test SE run',
 		'configs-tests/run_test.py',
 		'results/run_test/out',
-        self.gem5art,
+                self.gem5art,
 		self.gem5gitart,
 		self.runscptart,
 		'extra','params'


### PR DESCRIPTION
This patch changes the mentioned functions so that there is no
requirement on passing the path to gem5, kernel, and disk.
Instead these parameters are retrieved from their artifacts.